### PR TITLE
Feature/login

### DIFF
--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/uistate/UiState.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/uistate/UiState.kt
@@ -3,6 +3,7 @@ package com.rocket.cosmic_detox.presentation.uistate
 sealed interface UiState<out T> {
     data class Success<T>(val data: T): UiState<T>
     data class Failure(val e: Throwable?): UiState<Nothing>
+    data class SigningFailure(val e: Throwable?): UiState<Nothing>
     data object Loading: UiState<Nothing>
     data object Init: UiState<Nothing>
 }

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/mypage/MyPageFragment.kt
@@ -100,6 +100,7 @@ class MyPageFragment : Fragment() {
                 title = getString(R.string.dialog_sign_out),
                 onClickConfirm = {
                     FirebaseAuth.getInstance().signOut()
+
                     val intent = Intent(requireContext(), SignInActivity::class.java)
                     startActivity(intent)
                 },
@@ -240,6 +241,22 @@ class MyPageFragment : Fragment() {
                         OneButtonDialogFragment(
                             if(withdraw) getString(R.string.dialog_withdrawal_failure) else getString(R.string.dialog_sign_out_failure)) {}
                     dialog.isCancelable = false
+                    dialog.show(getParentFragmentManager(), "ConfirmDialog")
+                }
+                is UiState.SigningFailure -> {
+                    val dialog =
+                        TwoButtonDialogDescFragment(
+                            title = getString(R.string.dialog_withdrawal_logout_title),
+                            description = getString(R.string.dialog_withdrawal_logout_title),
+                            onClickConfirm = {
+                                FirebaseAuth.getInstance().signOut()
+
+                                val intent = Intent(requireContext(), SignInActivity::class.java)
+                                startActivity(intent)
+                            },
+                            onClickCancel = {})
+                    dialog.isCancelable = false
+                    dialog.show(getParentFragmentManager(), "ConfirmDialog")
                 }
                 else -> {
                     // 로딩 중

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/mypage/MyPageFragment.kt
@@ -17,18 +17,18 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.auth
 import com.rocket.cosmic_detox.R
 import com.rocket.cosmic_detox.data.model.AllowedApp
 import com.rocket.cosmic_detox.data.model.User
 import com.rocket.cosmic_detox.databinding.FragmentMyPageBinding
+import com.rocket.cosmic_detox.presentation.component.dialog.OneButtonDialogFragment
 import com.rocket.cosmic_detox.presentation.component.dialog.TwoButtonDialogDescFragment
 import com.rocket.cosmic_detox.presentation.component.dialog.TwoButtonDialogFragment
 import com.rocket.cosmic_detox.presentation.extensions.loadRankingPlanetImage
 import com.rocket.cosmic_detox.presentation.extensions.toHours
 import com.rocket.cosmic_detox.presentation.uistate.MyPageUiState
+import com.rocket.cosmic_detox.presentation.uistate.UiState
 import com.rocket.cosmic_detox.presentation.view.activity.SignInActivity
 import com.rocket.cosmic_detox.presentation.view.fragment.mypage.adapter.MyAppUsageAdapter
 import com.rocket.cosmic_detox.presentation.view.fragment.mypage.adapter.MyTrophyAdapter
@@ -70,7 +70,8 @@ class MyPageFragment : Fragment() {
         }
 
         binding.btnAllowAppSetting.setOnClickListener {
-            val action = MyPageFragmentDirections.actionMyToModifyAllowApp(allowedApps.toTypedArray())
+            val action =
+                MyPageFragmentDirections.actionMyToModifyAllowApp(allowedApps.toTypedArray())
             findNavController().navigate(action)
         }
         // 개인정보보호정책 및 이용약관
@@ -84,17 +85,8 @@ class MyPageFragment : Fragment() {
                 title = getString(R.string.dialog_withdrawal),
                 description = getString(R.string.dialog_withdrawal_desc),
                 onClickConfirm = {
-                    val user = Firebase.auth.currentUser!!
-                    Log.d("withdrawal2", user.email.toString())
-                    user.delete()
-                        .addOnCompleteListener { task ->
-                            if (task.isSuccessful) {
-                                val intent = Intent(requireContext(), SignInActivity::class.java)
-                                startActivity(intent)
-                                Log.d("withdrawal", "User account deleted.")
-                            }
-                        }
-                    Log.d("intent", "Intent Successfully")
+                    myPageViewModel.withdraw()
+                    setUiState()
                 },
                 onClickCancel = { false }
             )
@@ -119,7 +111,8 @@ class MyPageFragment : Fragment() {
     }
 
     private fun initView() = with(binding) {
-        val verticalSpaceHeight = resources.getDimensionPixelSize(R.dimen.item_app_usage_vertical_space)
+        val verticalSpaceHeight =
+            resources.getDimensionPixelSize(R.dimen.item_app_usage_vertical_space)
         rvMyAppUsage.apply {
             adapter = myAppUsageAdapter
             addItemDecoration(AppUsageItemDecoration(verticalSpaceHeight))
@@ -233,6 +226,26 @@ class MyPageFragment : Fragment() {
                 dialog.dismiss()
             }
             .show()
+    }
+
+    private fun setUiState(withdraw: Boolean = true) = lifecycleScope.launch {
+        myPageViewModel.userStatus.collectLatest {
+            when (it) {
+                is UiState.Success -> {
+                    val intent = Intent(requireContext(), SignInActivity::class.java)
+                    startActivity(intent)
+                }
+                is UiState.Failure -> {
+                    val dialog =
+                        OneButtonDialogFragment(
+                            if(withdraw) getString(R.string.dialog_withdrawal_failure) else getString(R.string.dialog_sign_out_failure)) {}
+                    dialog.isCancelable = false
+                }
+                else -> {
+                    // 로딩 중
+                }
+            }
+        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/mypage/MyPageViewModel.kt
@@ -102,13 +102,10 @@ class MyPageViewModel @Inject constructor(
             .addOnCompleteListener { task ->
                 if (task.isSuccessful) {
                     user.delete()
-                        .addOnCompleteListener { task ->
-                            Log.d("withdrawal2", "Working? ${task.isSuccessful}")
-                            if (task.isSuccessful) {
-                                Log.d("withdrawal", "User Authentication is deleted.")
+                        .addOnCompleteListener { deleteTask ->
+                            if (deleteTask.isSuccessful) {
+                                Log.d("withdrawal", "User Authentication and data is successfully deleted.")
                                 withdrawUserCoroutine(user)
-                            } else {
-                                Log.d("withdrawal failed", "${task.exception}")
                             }
                         }
                 } else {
@@ -116,8 +113,6 @@ class MyPageViewModel @Inject constructor(
                     Log.e("회원 재인증", "회원 재인증 실패", task.exception)
                 }
             }
-
-
     }
 
     private fun withdrawUserCoroutine(user: FirebaseUser) = viewModelScope.launch {

--- a/app/src/main/res/values-en/string.xml
+++ b/app/src/main/res/values-en/string.xml
@@ -59,6 +59,8 @@
     <string name="dialog_sign_out">Are you sure you want to sign out?</string>
     <string name="dialog_withdrawal">Are you sure you want to leave?</string>
     <string name="dialog_withdrawal_desc">After withdrawal, user information will be temporarily stored for 7 days, and will be permanently deleted.</string>
+    <string name="dialog_withdrawal_failure">Leave failed.</string>
+    <string name="dialog_sign_out_failure">Sign out failed.</string>
 
     <!--  Bottom Sheet  -->
     <string name="bottom_sheet_default">BottomSheet Default Title</string>

--- a/app/src/main/res/values-en/string.xml
+++ b/app/src/main/res/values-en/string.xml
@@ -60,6 +60,8 @@
     <string name="dialog_withdrawal">Are you sure you want to leave?</string>
     <string name="dialog_withdrawal_desc">After withdrawal, user information will be temporarily stored for 7 days, and will be permanently deleted.</string>
     <string name="dialog_withdrawal_failure">Leave failed.</string>
+    <string name="dialog_withdrawal_logout_title">Please re-certify your account!</string>
+    <string name="dialog_withdrawal_logout_desc">Please log out and log back in to proceed with the withdrawal. \n Do you want to log out?</string>
     <string name="dialog_sign_out_failure">Sign out failed.</string>
 
     <!--  Bottom Sheet  -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="dialog_sign_out">정말로 로그아웃 하시겠어요?</string>
     <string name="dialog_withdrawal">정말로 탈퇴하시겠어요?</string>
     <string name="dialog_withdrawal_desc">회원탈퇴 후 유저 정보는 7일 동안 임시 보관되며, 이후 영구 삭제됩니다.</string>
+    <string name="dialog_withdrawal_failure">탈퇴에 실패했습니다.</string>
+    <string name="dialog_sign_out_failure">로그아웃에 실패했습니다.</string>
 
     <!--  Timer  -->
     <string name="timer_start">타이머 시작</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -49,6 +49,8 @@
     <string name="dialog_withdrawal">정말로 탈퇴하시겠어요?</string>
     <string name="dialog_withdrawal_desc">회원탈퇴 후 유저 정보는 7일 동안 임시 보관되며, 이후 영구 삭제됩니다.</string>
     <string name="dialog_withdrawal_failure">탈퇴에 실패했습니다.</string>
+    <string name="dialog_withdrawal_logout_title">회원 인증을 다시 해주세요!</string>
+    <string name="dialog_withdrawal_logout_desc">로그아웃 하고 다시 로그인 하여 회원탈퇴를 진행해주세요.\n로그아웃 하시겠어요?</string>
     <string name="dialog_sign_out_failure">로그아웃에 실패했습니다.</string>
 
     <!--  Timer  -->


### PR DESCRIPTION
- 회원탈퇴 기능 수정
  - Firestore DB에서도 유저 정보 삭제 되도록 변경 (users, seasons 모두)
  - 로그인한지 시간 오래 지나면 민감한 작업을 수행하기 전에 사용자의 신원을 다시 확인하는 보안 메커니즘에 의거하여 재인증 해야함
    - 재인증 하는 로직 추가
    - 만약 재인증 실패하면 로그아웃 후 재로그인 하여 회원탈퇴할 수 있도록 안내 Dialog 띄우기 완료