### PR TITLE
허용 앱 bottom sheet가 열려 있을 때, bottom sheet를 벗어났을 때의 처리

### DIFF
--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/component/bottomsheet/TimerAllowedAppBottomSheet.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/component/bottomsheet/TimerAllowedAppBottomSheet.kt
@@ -53,10 +53,7 @@ class TimerAllowedAppBottomSheet : BottomSheetDialogFragment() {
             allowedAppViewModel.setSelectedAllowedAppPackage(packageId)
             allowedAppViewModel.startObserveAppOpenRunnable()
             val runnable = allowedAppViewModel.initObserveAppOpenRunnable(requireContext(), packageId) {
-                if (rootView == null) {
-                    showOverlay()
-                    allowedAppViewModel.stopObserveAppOpenRunnable()
-                }
+                if (rootView == null) showOverlay()
             }
             val thread = Thread(runnable)
             thread.start()
@@ -101,6 +98,15 @@ class TimerAllowedAppBottomSheet : BottomSheetDialogFragment() {
             allowedAppViewModel.getAllAllowedApps()
 
             countDownTimer?.cancel()
+            allowedAppViewModel.stopObserveAppOpenRunnable()
+        }
+    }
+
+    override fun onStop() {
+        super.onStop()
+
+        if (!allowedAppViewModel.running.value && BottomSheetState.getIsBottomSheetOpen()) {
+            if (rootView == null) showOverlay()
         }
     }
 

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/viewmodel/AllowedAppViewModel.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/viewmodel/AllowedAppViewModel.kt
@@ -32,7 +32,8 @@ class AllowedAppViewModel @Inject constructor(
     private val _selectedAllowedAppPackage = MutableStateFlow<String?>(null)
     val selectedAllowedAppPackage: StateFlow<String?> = _selectedAllowedAppPackage
 
-    private val _running = MutableStateFlow(true)
+    private val _running = MutableStateFlow(false)
+    val running: StateFlow<Boolean> = _running
 
     fun getAllAllowedApps() {
         viewModelScope.launch {


### PR DESCRIPTION
## 작업 내용
- thread running state 외부에서 쓸 수 있도록 추가.
- bottom sheet의 onstop에서 running state가 닫혀 있고, sheet가 열려 있을 때만 overlay 띄우는 로직 적용.

## Issue
- closed #82 