### PR TITLE
Fix: 타이머 화면 자정 지날 시 초기화 안 되는 버그

### DIFF
--- a/app/src/main/java/com/rocket/cosmic_detox/CosmicDetoxApplication.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/CosmicDetoxApplication.kt
@@ -86,4 +86,26 @@ class CosmicDetoxApplication : Application(), Configuration.Provider {
 
         Log.d("TimerService", "5분 후에 알람이 설정ㅇ")
     }
+
+    @SuppressLint("ScheduleExactAlarm")
+    fun scheduleDebugResetAlarmInOneMinute(context: Context) {
+        val alarmManager = context.getSystemService(ALARM_SERVICE) as AlarmManager
+        val intent = Intent(context, MidnightResetReceiver::class.java)
+            .setAction(MidnightResetReceiver.ACTION_MIDNIGHT_RESET)
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val triggerAtMillis = System.currentTimeMillis() + 20_000L
+        alarmManager.setExactAndAllowWhileIdle(
+            AlarmManager.RTC_WAKEUP,
+            triggerAtMillis,
+            pendingIntent
+        )
+
+        Log.d("TimerService", "디버그: 1분 뒤 자정 리셋 알람 예약")
+    }
 }

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/service/TimerService.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/service/TimerService.kt
@@ -85,8 +85,8 @@ class TimerService : LifecycleService() {
                 resetTimer()
             }
             else -> {
-                if (isTimerRunning) return START_STICKY
-                val dailyTime = intent?.getLongExtra("dailyTime", 0L) ?: 0L
+                if (isTimerRunning) return START_NOT_STICKY
+                val dailyTime = intent.getLongExtra("dailyTime", 0L)
                 initialDailyTime = dailyTime // 타이머 시작 시 dailyTime 저장
                 time = dailyTime // 전달받은 dailyTime으로 초기화
                 sessionElapsedTime = 0L
@@ -138,16 +138,27 @@ class TimerService : LifecycleService() {
 
     // Reset Timer 추가
     private fun resetTimer() {
+        val wasRunning = isTimerRunning
+
         // 타이머가 동작 중일 때는 먼저 멈춤
-        if (isTimerRunning) {
+        if (wasRunning) {
             handler.removeCallbacks(timerRunnable)
             isTimerRunning = false
             currentDailyTime = time // 타이머가 멈춘 시점의 시간을 저장
+        } else {
+            currentDailyTime = 0L
+        }
+
+        // 자정 시점에는 "이번 세션에서 아직 totalTime에 반영되지 않은 시간"만 누적
+        val elapsedSecondsToSave = if (wasRunning) {
+            sessionElapsedTime.coerceAtLeast((currentDailyTime - initialDailyTime).coerceAtLeast(0L))
+        } else {
+            0L
         }
 
         // 기존의 totalTime과 dailyTime을 가져옴
         getTotalTimeUseCase({ currentTotalTime ->
-            val updatedTotalTime = currentTotalTime + currentDailyTime // 기존 totalTime에 currentDailyTime을 더함
+            val updatedTotalTime = currentTotalTime + elapsedSecondsToSave
 
             // totalTime 업데이트 후 dailyTime 초기화
             updateTotalTimeUseCase(updatedTotalTime, {
@@ -155,10 +166,15 @@ class TimerService : LifecycleService() {
                     Log.d("TimerService", "dailyTime이 0으로 초기화되었습니다.")
                     time = 0L // 로컬 타이머도 0으로 초기화
                     initialDailyTime = 0L // resetTimer 후 타이머를 재시작할 때 다시 설정되도록 초기화
+                    sessionElapsedTime = 0L
                     sendTimeUpdate() // UI 업데이트
 
-                    // 타이머를 다시 시작
-                    startTimer()
+                    if (wasRunning) {
+                        // 타이머 실행 중 자정이 지난 경우: 0부터 즉시 재시작
+                        startTimer()
+                    } else {
+                        stopSelf()
+                    }
                 }, { exception ->
                     Log.e("TimerService", "dailyTime 초기화 실패: $exception")
                 })

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/settings/SettingsFragment.kt
@@ -11,10 +11,13 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.rocket.cosmic_detox.BuildConfig
+import com.rocket.cosmic_detox.CosmicDetoxApplication
 import com.rocket.cosmic_detox.R
 import com.rocket.cosmic_detox.databinding.FragmentSettingsBinding
 import com.rocket.cosmic_detox.presentation.component.dialog.TwoButtonDialogDescFragment
 import com.rocket.cosmic_detox.presentation.component.dialog.TwoButtonDialogFragment
+import com.rocket.cosmic_detox.presentation.service.TimerService
 import com.rocket.cosmic_detox.presentation.uistate.LoginUiState
 import com.rocket.cosmic_detox.presentation.view.activity.SignInActivity
 import com.rocket.cosmic_detox.presentation.viewmodel.UserViewModel
@@ -42,6 +45,21 @@ class SettingsFragment : Fragment() {
     ): View {
         with(binding) {
             tvAppVersion.text = getAppVersion()
+            if (BuildConfig.DEBUG) {
+                tvAppVersion.setOnClickListener {
+                    val app = requireContext().applicationContext as CosmicDetoxApplication
+                    app.scheduleDebugResetAlarmInOneMinute(requireContext())
+                    Toast.makeText(requireContext(), "디버그: 1분 뒤 자정 리셋 예약", Toast.LENGTH_SHORT).show()
+                }
+                tvAppVersion.setOnLongClickListener {
+                    val resetIntent = Intent(requireContext(), TimerService::class.java).apply {
+                        action = TimerService.ACTION_RESET_TIMER
+                    }
+                    requireContext().startService(resetIntent)
+                    Toast.makeText(requireContext(), "디버그: 자정 리셋 실행", Toast.LENGTH_SHORT).show()
+                    true
+                }
+            }
 
             layoutPrivacyPolicy.setOnClickListener { startLink(Uri.parse(PRIVACY_POLICY_LINK)) }
             layoutTermsOfService.setOnClickListener { startLink(Uri.parse(TERMS_OF_USE_LINK)) }

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/timer/TimerFragment.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/timer/TimerFragment.kt
@@ -156,7 +156,7 @@ class TimerFragment : Fragment() {
         }
 
         initView()
-        requireActivity().onBackPressedDispatcher.addCallback(requireActivity(), backPressedCallBack)
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backPressedCallBack)
         observeViewModel()
         userViewModel.fetchTotalTime()
         userViewModel.fetchDailyTime()
@@ -208,6 +208,7 @@ class TimerFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        backPressedCallBack.remove()
         super.onDestroyView()
         _binding = null
         stopTimerService()
@@ -308,6 +309,7 @@ class TimerFragment : Fragment() {
 
     private val backPressedCallBack = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
+            if (!isAdded || _binding == null) return
             showTwoButtonDialog()
         }
     }
@@ -340,11 +342,16 @@ class TimerFragment : Fragment() {
     }
 
     private fun showTwoButtonDialog() {
+        if (!isAdded || _binding == null) return
+        val fragmentManager = parentFragmentManager
+        if (fragmentManager.isStateSaved) return
+        if (fragmentManager.findFragmentByTag("ConfirmDialog") != null) return
+
         val dialog = OneButtonDialogFragment(
             getString(R.string.dialog_common_focus)
         ) {}
         dialog.isCancelable = false
-        dialog.show(parentFragmentManager, "ConfirmDialog")
+        dialog.show(fragmentManager, "ConfirmDialog")
     }
 
     private fun updateTime(time: Long) {

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/timer/TimerFragment.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/view/fragment/timer/TimerFragment.kt
@@ -37,8 +37,13 @@ import com.rocket.cosmic_detox.presentation.uistate.UiState
 import com.rocket.cosmic_detox.presentation.view.activity.MainActivity
 import com.rocket.cosmic_detox.presentation.viewmodel.PermissionViewModel
 import com.rocket.cosmic_detox.presentation.viewmodel.UserViewModel
+import com.rocket.cosmic_detox.util.SharedPreferencesUtil
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import androidx.core.net.toUri
 
 @AndroidEntryPoint
 class TimerFragment : Fragment() {
@@ -172,7 +177,7 @@ class TimerFragment : Fragment() {
             !Settings.canDrawOverlays(requireContext())) {
             val intent = Intent(
                 Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                Uri.parse("package:${requireContext().packageName}")
+                "package:${requireContext().packageName}".toUri()
             )
             overlayPermissionLauncher.launch(intent)
         }
@@ -313,7 +318,7 @@ class TimerFragment : Fragment() {
                 when (state) {
                     is UiState.Loading -> {}
                     is UiState.Success -> {
-                        val dailyTime = state.data
+                        val dailyTime = normalizeDailyTime(state.data)
                         updateTime(dailyTime)
                         startTimerService(dailyTime)
                     }
@@ -347,6 +352,25 @@ class TimerFragment : Fragment() {
         val minutes = (time % 3600) / 60
         val seconds = time % 60
         binding.tvTimerTime.text = String.format("%02d:%02d:%02d", hours, minutes, seconds)
+    }
+
+    private fun normalizeDailyTime(fetchedDailyTime: Long): Long {
+        val today = getTodayKey()
+        val lastResetDate = SharedPreferencesUtil.getLastDailyResetDate(requireContext())
+
+        return if (lastResetDate != today && fetchedDailyTime > 0L) {
+            userViewModel.updateDailyTime(0L)
+            SharedPreferencesUtil.setLastDailyResetDate(requireContext(), today)
+            0L
+        } else {
+            SharedPreferencesUtil.setLastDailyResetDate(requireContext(), today)
+            fetchedDailyTime
+        }
+    }
+
+    private fun getTodayKey(): String {
+        val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.KOREA)
+        return formatter.format(Date())
     }
 }
 

--- a/app/src/main/java/com/rocket/cosmic_detox/util/SharedPreferencesUtil.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/util/SharedPreferencesUtil.kt
@@ -1,11 +1,13 @@
 package com.rocket.cosmic_detox.util
 
 import android.content.Context
+import androidx.core.content.edit
 
 object SharedPreferencesUtil {
 
     private const val PREFS_NAME = "app_preferences"
     private const val FIRST_TIME_USER_KEY = "is_first_time_user"
+    private const val LAST_DAILY_RESET_DATE_KEY = "last_daily_reset_date"
 
     fun isFirstTimeUser(context: Context): Boolean {
         val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -15,5 +17,15 @@ object SharedPreferencesUtil {
     fun setFirstTimeUserCompleted(context: Context) {
         val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         sharedPreferences.edit().putBoolean(FIRST_TIME_USER_KEY, false).apply()
+    }
+
+    fun getLastDailyResetDate(context: Context): String? {
+        val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return sharedPreferences.getString(LAST_DAILY_RESET_DATE_KEY, null)
+    }
+
+    fun setLastDailyResetDate(context: Context, date: String) {
+        val sharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        sharedPreferences.edit { putString(LAST_DAILY_RESET_DATE_KEY, date) }
     }
 }


### PR DESCRIPTION
close #154 

## 📄 작업 내용

- 자정 리셋이 되지 않을 시 전날 dailyTime이 보이는 버그
- 디버그 시에만 테스트할 수 있는 코드 추가(설정 화면의 앱 버전 클릭, 롱 클릭)
- 타이머 화면 진입 후 복귀 시 다른 화면에서 뒤로가기하면 크래시 발생하는 버그 해결

## ✅ 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] 빌드 통과 확인

## 📸 스크린샷 (선택)
> UI 변경 사항이 있다면 이미지를 첨부해주세요.

## 🚨 버그 (선택)
> 버그가 있다면 재현 방법과 함께 설명해주세요.