### PR TITLE
Fix: 삭제된 앱 이미지 로드 로직 강화

### DIFF
--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/component/bottomsheet/adapter/AllowedAppAdapter.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/component/bottomsheet/adapter/AllowedAppAdapter.kt
@@ -45,7 +45,7 @@ class AllowedAppAdapter(
                         onItemClick(allowedApp.packageId, allowedApp.limitedTime, allowedApp.appName)
                     }
                 }
-                appIcon.loadAllowedAppIcon(context, allowedApp.packageId, allowedApp.appIcon)
+                appIcon.loadAllowedAppIcon(allowedApp.packageId, allowedApp.appIcon)
                 appName.text = allowedApp.appName
                 appUsageTime.text = getTimeString(allowedApp.limitedTime)
             }

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/component/bottomsheet/setlimitapp/LimitedAppAdapter.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/component/bottomsheet/setlimitapp/LimitedAppAdapter.kt
@@ -37,7 +37,7 @@ class LimitedAppAdapter(
                 onClick(item)
             }
             with(binding) {
-                ivDepthAppIcon.loadAllowedAppIcon(context, item.packageId, item.appIcon)
+                ivDepthAppIcon.loadAllowedAppIcon(item.packageId, item.appIcon)
                 tvAppDepthName.text = item.appName
                 tvAppDepthUsageTime.setCumulativeTime(item.limitedTime.toBigDecimal())
                 emphasizeDarkerLayoutDepth.isVisible = !context.isAppInstalled(item.packageId)

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/extensions/ImageViewExtensions.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/extensions/ImageViewExtensions.kt
@@ -1,6 +1,7 @@
 package com.rocket.cosmic_detox.presentation.extensions
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.core.view.setPadding
@@ -49,22 +50,21 @@ fun ImageView.loadRankingPlanetImage(cumulativeTime: BigDecimal) {
     setImageResource(imageResId)
 }
 
-fun ImageView.loadAllowedAppIcon(context: Context, packageId: String, appIcon: String) {
-    if (appIcon.isNotEmpty()) {
-        Glide.with(this)
-            .load(appIcon)
-            .apply(RequestOptions.bitmapTransform(RoundedCorners(12)))
-            .placeholder(R.drawable.shape_default_app_icon)
-            .error(R.drawable.shape_default_app_icon)
-            .into(this)
-    } else {
-        Glide.with(this)
-            .load(context.packageManager.getApplicationIcon(packageId))
-            .apply(RequestOptions.bitmapTransform(RoundedCorners(12)))
-            .placeholder(R.drawable.shape_default_app_icon)
-            .error(R.drawable.shape_default_app_icon)
-            .into(this)
+fun ImageView.loadAllowedAppIcon(packageId: String, appIcon: String) {
+    val icon = try {
+        context.packageManager.getApplicationIcon(packageId)
+    } catch (e: PackageManager.NameNotFoundException) {
+        appIcon.ifEmpty {
+            R.drawable.shape_default_app_icon
+        }
     }
+
+    Glide.with(this)
+        .load(icon)
+        .apply(RequestOptions.bitmapTransform(RoundedCorners(12)))
+        .placeholder(R.drawable.shape_default_app_icon)
+        .error(R.drawable.shape_default_app_icon)
+        .into(this)
 }
 
 fun ImageView.loadInstalledAppIcon(appIconBitmap: Bitmap) {

--- a/app/src/main/java/com/rocket/cosmic_detox/presentation/extensions/NumberExtensions.kt
+++ b/app/src/main/java/com/rocket/cosmic_detox/presentation/extensions/NumberExtensions.kt
@@ -3,7 +3,6 @@ package com.rocket.cosmic_detox.presentation.extensions
 import android.content.Context
 import java.math.BigDecimal
 
-// dp 값을 px로 변환
 fun Int.dpToPx(context: Context): Int {
     val density = context.resources.displayMetrics.density
     return (this * density).toInt()
@@ -33,7 +32,6 @@ fun Long.fromMinutesToSeconds(): Long {
     return this * 60
 }
 
-// ms -> s
 fun BigDecimal.fromMillisecondsToSeconds(): BigDecimal {
     return this.divide(BigDecimal(1000))
 }


### PR DESCRIPTION
close #이슈번호

## 📄 작업 내용

- 기존: Storage에서 받아온 url, 없으면 PackageManager에서 가져온 Drawable
- 기존 방식은 대부분의 케이스에서는 문제 없음
- 하지만 허용 앱 추가 -> 해당 앱 바로 삭제 -> 바로 우리 앱 복귀 후 바텀시트 연다면?
    - 아직 url을 받아오진 못한 상태라 PackageManager에서 가져와야 하는데 이미 삭제되어있어서 버그 발생

**해결**
- 디폴트 값: PackageManger에서 가져옴.
- 없으면 삭제되었거나 해당 기기에 앱이 없음 -> url -> url도 없으면 기본 회색 상자.


## ✅ 체크리스트
- [x] Assignees 설정
- [x] Labels 설정
- [x] Projects 설정
- [x] 빌드 통과 확인

## 📸 스크린샷 (선택)
> UI 변경 사항이 있다면 이미지를 첨부해주세요.

## 🚨 버그 (선택)
> 버그가 있다면 재현 방법과 함께 설명해주세요.